### PR TITLE
feat: created logic layer for stock view model

### DIFF
--- a/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/MaterialDto.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/MaterialDto.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.dto;
+
+import lombok.*;
+import org.eclipse.tractusx.puris.backend.stock.logic.dto.StockDto;
+
+import java.io.Serializable;
+import java.util.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@ToString
+@NoArgsConstructor
+public class MaterialDto implements Serializable {
+
+    private UUID uuid;
+
+    @Setter(AccessLevel.NONE)
+    private Set<PartnerDto> suppliedByPartners = new HashSet<>();
+
+    @Setter(AccessLevel.NONE)
+    private Set<PartnerDto> orderedByPartners = new HashSet<>();
+
+    @Setter(AccessLevel.NONE)
+    private List<StockDto> materialOnStocks = new ArrayList<>();
+
+    /**
+     * If true, then the Material is a material (input for production / something I buy).
+     * <p>
+     * Boolean because there could be companies (tradesmen company) that buy and sell the same material.
+     */
+    private boolean materialFlag;
+
+    /**
+     * If true, then the Material is a product (output of production / something I sell).
+     * <p>
+     * Boolean because there could be companies (tradesmen company) that buy and sell the same material.
+     */
+    private boolean productFlag;
+
+    private String materialNumberCustomer;
+
+    private String materialNumberSupplier;
+
+    private String materialNumberCx;
+
+    private String name;
+
+    public MaterialDto(boolean materialFlag, boolean productFlag, String materialNumberCustomer, String materialNumberSupplier, String materialNumberCx, String name) {
+        super();
+        this.materialFlag = materialFlag;
+        this.productFlag = productFlag;
+        this.materialNumberCustomer = materialNumberCustomer;
+        this.materialNumberSupplier = materialNumberSupplier;
+        this.materialNumberCx = materialNumberCx;
+        this.name = name;
+    }
+
+    public void addSuppliedByPartner(PartnerDto supplierPartner) {
+        this.suppliedByPartners.add(supplierPartner);
+        supplierPartner.getSuppliesMaterials().add(this);
+    }
+
+    public void addOrderedByPartner(PartnerDto customerPartner) {
+        this.orderedByPartners.add(customerPartner);
+        customerPartner.getOrdersProducts().add(this);
+    }
+
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/PartnerDto.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/PartnerDto.java
@@ -1,0 +1,71 @@
+package org.eclipse.tractusx.puris.backend.masterdata.logic.dto;
+
+import jakarta.annotation.Nullable;
+import lombok.*;
+import org.eclipse.tractusx.puris.backend.stock.logic.dto.PartnerProductStockDto;
+import org.eclipse.tractusx.puris.backend.stock.logic.dto.ProductStockDto;
+
+import java.io.Serializable;
+import java.util.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class PartnerDto implements Serializable {
+
+    private UUID uuid;
+    private String name;
+
+    private boolean actsAsCustomerFlag;
+    private boolean actsAsSupplierFlag;
+
+    private String edcUrl;
+    private String bpnl;
+    private String siteBpns;
+
+    @Nullable
+    @ToString.Exclude
+    @Setter(AccessLevel.NONE)
+    private Set<MaterialDto> suppliesMaterials = new HashSet<>();
+
+    @Nullable
+    @ToString.Exclude
+    @Setter(AccessLevel.NONE)
+    private Set<MaterialDto> ordersProducts = new HashSet<>();
+
+    @ToString.Exclude
+    @Setter(AccessLevel.NONE)
+    private List<ProductStockDto> allocatedProductStocksForCustomer = new ArrayList<>();
+
+    @ToString.Exclude
+    @Setter(AccessLevel.NONE)
+    private List<PartnerProductStockDto> partnerProductStocks = new ArrayList<>();
+
+    public PartnerDto(String name, boolean actsAsCustomerFlag, boolean actsAsSupplierFlag, String edcUrl, String bpnl, String siteBpns) {
+        super();
+        this.name = name;
+        this.actsAsCustomerFlag = actsAsCustomerFlag;
+        this.actsAsSupplierFlag = actsAsSupplierFlag;
+        this.edcUrl = edcUrl;
+        this.bpnl = bpnl;
+        this.siteBpns = siteBpns;
+    }
+
+    public void addSuppliedMaterial(MaterialDto suppliedMaterial) {
+        this.suppliesMaterials.add(suppliedMaterial);
+        suppliedMaterial.getSuppliedByPartners().add(this);
+    }
+
+    public void addOrderedProduct(MaterialDto orderedProduct) {
+        this.ordersProducts.add(orderedProduct);
+        orderedProduct.getOrderedByPartners().add(this);
+    }
+
+    public void addPartnerProductStock(PartnerProductStockDto partnerProductStockDto) {
+        this.partnerProductStocks.add(partnerProductStockDto);
+        partnerProductStockDto.setSupplierPartner(this);
+    }
+
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialService.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
+
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public interface MaterialService {
+
+    Material create(Material material);
+
+    Material update(Material material);
+
+    List<Material> findAllMaterials();
+
+    List<Material> findAllProducts();
+
+    Material findByUuid(UUID materialUuid);
+
+    Material findMaterialByMaterialNumberCustomer(String materialNumberCustomer);
+
+    Material findProductByMaterialNumberCustomer(String materialNumberCustomer);
+
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialServiceImpl.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialServiceImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
+
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.repository.MaterialRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class MaterialServiceImpl implements MaterialService {
+
+    @Autowired
+    MaterialRepository materialRepository;
+
+    @Override
+    public Material create(Material material) {
+        return materialRepository.save(material);
+    }
+
+    @Override
+    public Material update(Material material) {
+        Optional<Material> existingMaterial =
+                materialRepository.findById(material.getUuid());
+
+        if (existingMaterial.isPresent()) {
+            return existingMaterial.get();
+        } else return null;
+    }
+
+    @Override
+    public List<Material> findAllMaterials() {
+        return materialRepository.findAllByMaterialFlagIsTrue();
+    }
+
+    @Override
+    public List<Material> findAllProducts() {
+        return materialRepository.findAllByProductFlagIsTrue();
+    }
+
+    @Override
+    public Material findByUuid(UUID materialUuid) {
+        Optional<Material> foundMaterial = materialRepository.findById(materialUuid);
+
+        if (!foundMaterial.isPresent()) {
+            return null;
+        }
+        return foundMaterial.get();
+    }
+
+    @Override
+    public Material findMaterialByMaterialNumberCustomer(String materialNumberCustomer) {
+
+        Optional<Material> foundMaterial =
+                materialRepository.findByMaterialNumberCustomerAndMaterialFlagIsTrue(materialNumberCustomer);
+
+        if (!foundMaterial.isPresent()) {
+            return null;
+        }
+        return foundMaterial.get();
+    }
+
+    @Override
+    public Material findProductByMaterialNumberCustomer(String materialNumberCustomer) {
+        Optional<Material> foundProduct =
+                materialRepository.findByMaterialNumberCustomerAndProductFlagIsTrue(materialNumberCustomer);
+
+        if (!foundProduct.isPresent()) {
+            return null;
+        }
+        return foundProduct.get();
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/PartnerService.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/PartnerService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
+
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public interface PartnerService {
+
+    Partner create(Partner partner);
+
+    Partner findByUuid(UUID partnerUuid);
+
+    List<Partner> findAllCustomerPartnersForMaterialId(UUID materialUuid);
+
+    Partner update(Partner partner);
+
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/PartnerServiceImpl.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/PartnerServiceImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
+
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.repository.PartnerRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class PartnerServiceImpl implements PartnerService {
+
+    @Autowired
+    private PartnerRepository partnerRepository;
+
+
+    @Override
+    public Partner create(Partner partner) {
+        return partnerRepository.save(partner);
+    }
+
+    @Override
+    public Partner findByUuid(UUID partnerUuid) {
+        Optional<Partner> foundPartner = partnerRepository.findById(partnerUuid);
+
+        if (!foundPartner.isPresent()) {
+            return null;
+        }
+        return foundPartner.get();
+    }
+
+    @Override
+    public List<Partner> findAllCustomerPartnersForMaterialId(UUID materialUuid) {
+        return partnerRepository.findAllByActsAsCustomerFlagIsTrueAndOrdersProducts_Uuid(materialUuid);
+    }
+
+    @Override
+    public Partner update(Partner partner) {
+        Optional<Partner> existingPartner =
+                partnerRepository.findById(partner.getUuid());
+
+        if (existingPartner.isPresent()) {
+            return existingPartner.get();
+        } else return null;
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/MaterialStockDto.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/MaterialStockDto.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MaterialStockDto extends StockDto {
+
+    public MaterialStockDto(MaterialDto material, double quantity, String atSiteBpnl) {
+        super(material, quantity, atSiteBpnl, new Date());
+        this.setType(DT_StockTypeEnum.MATERIAL);
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/PartnerProductStockDto.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/PartnerProductStockDto.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.PartnerDto;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PartnerProductStockDto extends StockDto {
+
+    private PartnerDto supplierPartner;
+
+    public PartnerProductStockDto(MaterialDto material, double quantity, String atSiteBpnl) {
+        super(material, quantity, atSiteBpnl, new Date());
+        this.setType(DT_StockTypeEnum.PRODUCT);
+    }
+
+    public PartnerProductStockDto(MaterialDto material, double quantity, String atSiteBpnl,
+                                  PartnerDto supplierPartner) {
+        super(material, quantity, atSiteBpnl, new Date());
+        this.setType(DT_StockTypeEnum.PRODUCT);
+        this.supplierPartner = supplierPartner;
+        supplierPartner.addPartnerProductStock(this);
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ProductStockDto.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ProductStockDto.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.PartnerDto;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProductStockDto extends StockDto {
+
+    private PartnerDto allocatedToCustomerPartner;
+
+    public ProductStockDto(MaterialDto material, double quantity, String atSiteBpnl) {
+        super(material, quantity, atSiteBpnl, new Date());
+        this.setType(DT_StockTypeEnum.PRODUCT);
+    }
+
+    public ProductStockDto(MaterialDto material, double quantity, String atSiteBpnl,
+                           PartnerDto allocatedToCustomerPartner) {
+        super(material, quantity, atSiteBpnl, new Date());
+        this.setType(DT_StockTypeEnum.PRODUCT);
+        setAllocatedToCustomerPartner(allocatedToCustomerPartner);
+    }
+
+    public void setAllocatedToCustomerPartner(PartnerDto allocatedToCustomerPartner) {
+        this.allocatedToCustomerPartner = allocatedToCustomerPartner;
+        allocatedToCustomerPartner.getAllocatedProductStocksForCustomer().add(this);
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/StockDto.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/StockDto.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.UUID;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public abstract class StockDto implements Serializable {
+
+    private UUID uuid;
+
+    private MaterialDto material;
+
+    private double quantity;
+
+    private String atSiteBpnl;
+
+    private DT_StockTypeEnum type;
+
+    private Date lastUpdatedOn;
+
+    public StockDto(MaterialDto material, double quantity, String atSiteBpnl, Date lastUpdatedOn) {
+        this.material = material;
+        this.quantity = quantity;
+        this.atSiteBpnl = atSiteBpnl;
+        this.lastUpdatedOn = lastUpdatedOn;
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/MaterialStockService.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/MaterialStockService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.service;
+
+import org.eclipse.tractusx.puris.backend.stock.domain.model.MaterialStock;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public interface MaterialStockService {
+
+    MaterialStock create(MaterialStock materialStock);
+
+    List<MaterialStock> findAll();
+
+    MaterialStock findByUuid(UUID materialStockUuid);
+
+    List<MaterialStock> findAllByMaterialNumberCustomer(String materialNumberCustomer);
+
+    MaterialStock update(MaterialStock materialStock);
+
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/MaterialStockServiceImpl.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/MaterialStockServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.service;
+
+import org.eclipse.tractusx.puris.backend.stock.domain.model.MaterialStock;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.repository.MaterialStockRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class MaterialStockServiceImpl implements MaterialStockService {
+
+    @Autowired
+    MaterialStockRepository materialStockRepository;
+
+    @Override
+    public MaterialStock create(MaterialStock materialStock) {
+        return materialStockRepository.save(materialStock);
+    }
+
+    @Override
+    public List<MaterialStock> findAll() {
+        return materialStockRepository.findAllByType(DT_StockTypeEnum.MATERIAL);
+    }
+
+    @Override
+    public MaterialStock findByUuid(UUID materialStockUuid) {
+
+        Optional<MaterialStock> foundMaterialStock = materialStockRepository.findById(materialStockUuid);
+
+        if (!foundMaterialStock.isPresent()) {
+            return null;
+        }
+        return foundMaterialStock.get();
+    }
+
+    @Override
+    public List<MaterialStock> findAllByMaterialNumberCustomer(String materialNumberCustomer) {
+        return materialStockRepository.findAllByMaterial_MaterialNumberCustomerAndType(materialNumberCustomer, DT_StockTypeEnum.MATERIAL);
+    }
+
+    @Override
+    public MaterialStock update(MaterialStock materialStock) {
+
+        Optional<MaterialStock> existingStock = materialStockRepository.findById(materialStock.getUuid());
+
+        if (existingStock.isPresent() && existingStock.get().getType() == DT_StockTypeEnum.MATERIAL) {
+            return existingStock.get();
+        } else return null;//TODO error handling: Updated MaterialStock is not material
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/PartnerProductStockService.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/PartnerProductStockService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.service;
+
+import org.eclipse.tractusx.puris.backend.stock.domain.model.PartnerProductStock;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public interface PartnerProductStockService {
+
+    PartnerProductStock create(PartnerProductStock partnerProductStock);
+
+    List<PartnerProductStock> findAll();
+
+    List<PartnerProductStock> findAllByMaterialUuid(UUID materialUuid);
+
+    PartnerProductStock update(PartnerProductStock partnerProductStock);
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/PartnerProductStockServiceImpl.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/PartnerProductStockServiceImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.service;
+
+import org.eclipse.tractusx.puris.backend.stock.domain.model.PartnerProductStock;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.repository.PartnerProductStockRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class PartnerProductStockServiceImpl implements PartnerProductStockService {
+
+    @Autowired
+    PartnerProductStockRepository partnerProductStockRepository;
+
+    @Override
+    public PartnerProductStock create(PartnerProductStock partnerProductStock) {
+        return partnerProductStockRepository.save(partnerProductStock);
+    }
+
+    @Override
+    public List<PartnerProductStock> findAll() {
+        return partnerProductStockRepository.findAllByType(DT_StockTypeEnum.PRODUCT);
+    }
+
+    @Override
+    public List<PartnerProductStock> findAllByMaterialUuid(UUID materialUuid) {
+        return partnerProductStockRepository.findAllByMaterial_UuidAndType(materialUuid, DT_StockTypeEnum.PRODUCT);
+    }
+
+    @Override
+    public PartnerProductStock update(PartnerProductStock partnerProductStock) {
+
+        Optional<PartnerProductStock> existingStock = partnerProductStockRepository.findById(partnerProductStock.getUuid());
+
+        if (existingStock.isPresent() && existingStock.get().getType() == DT_StockTypeEnum.PRODUCT) {
+            return existingStock.get();
+        } else
+            return null;
+    }
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ProductStockService.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ProductStockService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.service;
+
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStock;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public interface ProductStockService {
+
+    ProductStock create(ProductStock productStock);
+
+    ProductStock update(ProductStock productStock);
+
+    List<ProductStock> findAll();
+
+    ProductStock findByUuid(UUID productStockUuid);
+
+    List<ProductStock> findAllByMaterialNumberCustomer(String materialNumberCustomer);
+
+}

--- a/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ProductStockServiceImpl.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ProductStockServiceImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.stock.logic.service;
+
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStock;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.repository.ProductStockRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class ProductStockServiceImpl implements ProductStockService {
+
+    @Autowired
+    ProductStockRepository productStockRepository;
+
+    @Override
+    public ProductStock create(ProductStock productStock) {
+        return productStockRepository.save(productStock);
+    }
+
+    @Override
+    public List<ProductStock> findAll() {
+        return productStockRepository.findAllByType(DT_StockTypeEnum.PRODUCT);
+    }
+
+    @Override
+    public ProductStock findByUuid(UUID productStockUuid) {
+        Optional<ProductStock> foundProductStock =
+                productStockRepository.findById(productStockUuid);
+
+        if (!foundProductStock.isPresent()) {
+            return null;
+        }
+        return foundProductStock.get();
+    }
+
+    @Override
+    public List<ProductStock> findAllByMaterialNumberCustomer(String materialNumberCustomer) {
+        return productStockRepository.findAllByMaterial_MaterialNumberCustomerAndType(materialNumberCustomer, DT_StockTypeEnum.MATERIAL);
+    }
+
+    @Override
+    public ProductStock update(ProductStock productStock) {
+
+        Optional<ProductStock> existingStock = productStockRepository.findById(productStock.getUuid());
+
+        if (existingStock.isPresent() && existingStock.get().getType() == DT_StockTypeEnum.PRODUCT) {
+            return existingStock.get();
+        } else
+            return null;
+    }
+}


### PR DESCRIPTION
Incorporation of the logic layer providing necessary services for the stock view.

The logic layer separates the data access layer from the business logic. The logic layer combines further services (not rest) providing only the data access needed for the stock view in frontend. It already provides Dto that may be used in the controller. Open: Mapper Entity <-> Dto.

Currently documentation is missing due to a presentation deadline. We'll pay the debt after the presentation.


@mhellmeier Please review.