### PR TITLE
fix: changed dependency spring-boot parent to 3.0.7 and snakeyaml to 2.0

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,23 +1,23 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3435
 maven/mavencentral/ch.qos.logback/logback-core/1.4.7, EPL-1.0 OR LGPL-2.1-only, approved, #3373
-maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.2, Apache-2.0, approved, #5303
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.2, Apache-2.0 AND MIT, approved, #4303
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.2, Apache-2.0, approved, #4105
-maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.2, Apache-2.0, approved, #5933
+maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.14.3, Apache-2.0, approved, #5303
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.14.3, Apache-2.0 AND MIT, approved, #4303
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.3, Apache-2.0, approved, #4105
+maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.3, Apache-2.0, approved, #5933
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.14.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.2, Apache-2.0, approved, #4699
-maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.14.2, Apache-2.0, approved, #5938
+maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.3, Apache-2.0, approved, #4699
+maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.14.3, Apache-2.0, approved, #5938
 maven/mavencentral/com.fasterxml/classmate/1.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okhttp/okhttp/2.7.5, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.squareup.okio/okio/1.6.0, Apache-2.0, approved, CQ11382
 maven/mavencentral/com.zaxxer/HikariCP/5.0.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.github.classgraph/classgraph/4.8.149, MIT, approved, CQ22530
-maven/mavencentral/io.micrometer/micrometer-commons/1.10.6, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
-maven/mavencentral/io.micrometer/micrometer-observation/1.10.6, Apache-2.0, approved, #7331
+maven/mavencentral/io.micrometer/micrometer-commons/1.10.7, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #7333
+maven/mavencentral/io.micrometer/micrometer-observation/1.10.7, Apache-2.0, approved, #7331
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
 maven/mavencentral/io.swagger.core.v3/swagger-models-jakarta/2.2.7, Apache-2.0, approved, #5919
-maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.1, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
+maven/mavencentral/jakarta.activation/jakarta.activation-api/2.1.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 maven/mavencentral/jakarta.annotation/jakarta.annotation-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.ca
 maven/mavencentral/jakarta.persistence/jakarta.persistence-api/3.1.0, EPL-2.0 OR BSD-3-Clause AND (EPL-2.0 OR BSD-3-Clause AND BSD-3-Clause), approved, #7696
 maven/mavencentral/jakarta.transaction/jakarta.transaction-api/2.0.1, EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, #7697
@@ -40,37 +40,37 @@ maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-common/2.0.2, Apache-2.0, approved, #5920
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-api/2.0.2, Apache-2.0, approved, #5950
 maven/mavencentral/org.springdoc/springdoc-openapi-starter-webmvc-ui/2.0.2, Apache-2.0, approved, #5923
-maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.6, Apache-2.0, approved, #6981
-maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.0.6, Apache-2.0, approved, #6973
-maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.0.6, Apache-2.0, approved, #6965
-maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.0.6, Apache-2.0, approved, #7351
-maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.0.6, Apache-2.0, approved, #6974
-maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.6, Apache-2.0, approved, #7006
-maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.6, Apache-2.0, approved, #6982
-maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.0.6, Apache-2.0, approved, #7329
-maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.0.6, Apache-2.0, approved, #6987
-maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.0.6, Apache-2.0, approved, #5945
-maven/mavencentral/org.springframework.boot/spring-boot-starter/3.0.6, Apache-2.0, approved, #7330
-maven/mavencentral/org.springframework.boot/spring-boot/3.0.6, Apache-2.0, approved, #7327
-maven/mavencentral/org.springframework.data/spring-data-commons/3.0.5, Apache-2.0, approved, #5943
-maven/mavencentral/org.springframework.data/spring-data-jpa/3.0.5, Apache-2.0, approved, #5935
+maven/mavencentral/org.springframework.boot/spring-boot-autoconfigure/3.0.7, Apache-2.0, approved, #6981
+maven/mavencentral/org.springframework.boot/spring-boot-configuration-processor/3.0.7, Apache-2.0, approved, #6973
+maven/mavencentral/org.springframework.boot/spring-boot-starter-aop/3.0.7, Apache-2.0, approved, #6965
+maven/mavencentral/org.springframework.boot/spring-boot-starter-data-jpa/3.0.7, Apache-2.0, approved, #7351
+maven/mavencentral/org.springframework.boot/spring-boot-starter-jdbc/3.0.7, Apache-2.0, approved, #6974
+maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.0.7, Apache-2.0, approved, #7006
+maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.0.7, Apache-2.0, approved, #6982
+maven/mavencentral/org.springframework.boot/spring-boot-starter-security/3.0.7, Apache-2.0, approved, #7329
+maven/mavencentral/org.springframework.boot/spring-boot-starter-tomcat/3.0.7, Apache-2.0, approved, #6987
+maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.0.7, Apache-2.0, approved, #5945
+maven/mavencentral/org.springframework.boot/spring-boot-starter/3.0.7, Apache-2.0, approved, #7330
+maven/mavencentral/org.springframework.boot/spring-boot/3.0.7, Apache-2.0, approved, #7327
+maven/mavencentral/org.springframework.data/spring-data-commons/3.0.6, Apache-2.0, approved, #5943
+maven/mavencentral/org.springframework.data/spring-data-jpa/3.0.6, Apache-2.0, approved, #5935
 maven/mavencentral/org.springframework.security/spring-security-config/6.0.3, Apache-2.0, approved, #7338
 maven/mavencentral/org.springframework.security/spring-security-core/6.0.3, Apache-2.0, approved, #7325
 maven/mavencentral/org.springframework.security/spring-security-crypto/6.0.3, Apache-2.0 AND ISC, approved, #7326
 maven/mavencentral/org.springframework.security/spring-security-web/6.0.3, Apache-2.0, approved, #7328
 maven/mavencentral/org.springframework.session/spring-session-core/3.0.1, Apache-2.0, approved, #7858
-maven/mavencentral/org.springframework/spring-aop/6.0.8, Apache-2.0, approved, #5940
-maven/mavencentral/org.springframework/spring-aspects/6.0.8, Apache-2.0, approved, #5930
-maven/mavencentral/org.springframework/spring-beans/6.0.8, Apache-2.0, approved, #5937
-maven/mavencentral/org.springframework/spring-context/6.0.8, Apache-2.0, approved, #5936
-maven/mavencentral/org.springframework/spring-core/6.0.8, Apache-2.0 AND BSD-3-Clause, approved, #5948
-maven/mavencentral/org.springframework/spring-expression/6.0.8, Apache-2.0, approved, #3284
-maven/mavencentral/org.springframework/spring-jcl/6.0.8, Apache-2.0, approved, #3283
-maven/mavencentral/org.springframework/spring-jdbc/6.0.8, Apache-2.0, approved, #5924
-maven/mavencentral/org.springframework/spring-orm/6.0.8, Apache-2.0, approved, #5925
-maven/mavencentral/org.springframework/spring-tx/6.0.8, Apache-2.0, approved, #5926
-maven/mavencentral/org.springframework/spring-web/6.0.8, Apache-2.0, approved, #5942
-maven/mavencentral/org.springframework/spring-webmvc/6.0.8, Apache-2.0, approved, #5944
+maven/mavencentral/org.springframework/spring-aop/6.0.9, Apache-2.0, approved, #5940
+maven/mavencentral/org.springframework/spring-aspects/6.0.9, Apache-2.0, approved, #5930
+maven/mavencentral/org.springframework/spring-beans/6.0.9, Apache-2.0, approved, #5937
+maven/mavencentral/org.springframework/spring-context/6.0.9, Apache-2.0, approved, #5936
+maven/mavencentral/org.springframework/spring-core/6.0.9, Apache-2.0 AND BSD-3-Clause, approved, #5948
+maven/mavencentral/org.springframework/spring-expression/6.0.9, Apache-2.0, approved, #3284
+maven/mavencentral/org.springframework/spring-jcl/6.0.9, Apache-2.0, approved, #3283
+maven/mavencentral/org.springframework/spring-jdbc/6.0.9, Apache-2.0, approved, #5924
+maven/mavencentral/org.springframework/spring-orm/6.0.9, Apache-2.0, approved, #5925
+maven/mavencentral/org.springframework/spring-tx/6.0.9, Apache-2.0, approved, #5926
+maven/mavencentral/org.springframework/spring-web/6.0.9, Apache-2.0, approved, #5942
+maven/mavencentral/org.springframework/spring-webmvc/6.0.9, Apache-2.0, approved, #5944
 maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
 maven/mavencentral/org.webjars/webjars-locator-core/0.52, MIT, approved, clearlydefined
-maven/mavencentral/org.yaml/snakeyaml/1.33, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.6</version>
+        <version>3.0.7</version>
         <relativePath/>
     </parent>
     <groupId>org.eclipse.tractusx.puris</groupId>
@@ -44,6 +44,7 @@
         <jackson.version>2.14.2</jackson.version>
         <semantic-sds.version>2.1.3</semantic-sds.version>
         <modelmapper.version>3.1.1</modelmapper.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Updating to spring-boot-parent 3.1.0 is causing some non-trivial problems. Among other things the "NotYetImplementedException" in class ProductStockRequestApiServiceImpl is no longer contained in the modules of version 3.1.0. While this can be rather easily fixed by replacing that Exception class with e.g. a normal RuntimeException, the troubles unfortunately won´t end there. 

Beyond that I have consistently experienced errors while trying to create a build from our project under spring-boot-parent version 3.1.0: 

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: class org.hibernate.mapping.BasicValue cannot be cast to class org.hibernate.mapping.ToOne (org.hibernate.mapping.BasicValue and org.hibernate.mapping.ToOne are in unnamed module of loader 'app')

At the moment I am unfortunately unable to get to the bottom of this problem. So I´d strongly recommend to stick to the newest version that currently works with our project (i.e 3.0.7). And, after all, an upgrade to 3.1.0. is currently not needed to pass the tests of VeraCode. 

Aside from that, the explicit inclusion of snakeyaml version 2.0 is neccessary to pass the VeraCode test. Spring-boot-parent (even in version 3.1.0) includes only version 1.33, which is deemed unsafe: 

https://nvd.nist.gov/vuln/detail/CVE-2022-25857

Since the spring-boot creators have (for reasons of backward compatibility) decided, not to move on to version 2.0, it is necessary for us to do this ourselves. 