### PR TITLE
fix: removed JSONException from EdcAdapterService

### DIFF
--- a/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -29,7 +29,6 @@ import org.eclipse.tractusx.puris.backend.common.edc.logic.util.EDCRequestBodyBu
 import org.eclipse.tractusx.puris.backend.model.repo.OrderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.configurationprocessor.json.JSONException;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -129,8 +128,7 @@ public class EdcAdapterService {
      * @throws IOException   if REST calls for creation could not be sent
      * @throws JSONException if createAssetDto could not be parsed into JsonNode
      */
-    public boolean publishAssetAtEDC(CreateAssetDto createAssetDto) throws IOException,
-            JSONException {
+    public boolean publishAssetAtEDC(CreateAssetDto createAssetDto) throws IOException {
 
         String assetId = createAssetDto.getAssetDto().getPropertiesDto().getId();
 


### PR DESCRIPTION
The method publishAssetAtEDC had "throws JSONException" in its signature. This was not needed, since there is no such exception thrown in the method body. And aside from that this was causing servere problems under some circumstances. 